### PR TITLE
feat: hide nulls, add --show-null

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,8 @@
+## WIP  TBD
+
+ * Hide null values from extra fields section.
+ * Add the `--show-null` option to show null values in extra fields section.
+
 ## 0.0.1  2025-02-13
 
  * Initial release.

--- a/cmd.go
+++ b/cmd.go
@@ -32,6 +32,7 @@ var (
 	callerField            string
 	trimFields             []string
 	version                bool
+	showNull               bool
 )
 
 func init() {
@@ -47,6 +48,7 @@ func init() {
 	cmd.Flags().StringVarP(&msgFormat, "message-format", "m", "", "set the message format using gotemplate")
 	cmd.Flags().StringArrayVarP(&trimFields, "trim-field", "T", []string{"level", "msg", "stacktrace", "error"}, "set fields to trim from the output")
 	cmd.Flags().BoolVar(&version, "version", false, "print the version and exit")
+	cmd.Flags().BoolVar(&showNull, "show-null", false, "show null values in output")
 }
 
 // setupInput sets up the input file handle based on command-line input or returns err.

--- a/output.go
+++ b/output.go
@@ -48,7 +48,7 @@ func outputFormattedLogLine(
 	// 	delete(lineData, "msg")
 	// }
 
-	error, _ := getString(lineData, "error")
+	errorStr, _ := getString(lineData, "error")
 	st, _ := getString(lineData, "stacktrace")
 
 	for _, field := range trimFields {
@@ -68,6 +68,16 @@ func outputFormattedLogLine(
 	}
 
 	if len(lineData) > 0 {
+		if !showNull {
+			keepData := make(map[string]any, len(lineData))
+			for k, v := range lineData {
+				if v != nil {
+					keepData[k] = v
+				}
+			}
+			lineData = keepData
+		}
+
 		// If this has an error, we have something in the logs that can be
 		// parsed from JSON but not put back into JSON? Seems unlikely.
 		lineDataBytes, _ := json.Marshal(lineData)
@@ -80,8 +90,8 @@ func outputFormattedLogLine(
 	f += "\n"
 	_, _ = fmt.Fprintf(out, f, args...)
 
-	if error != "" {
-		fmt.Fprintln(out, c.C(ColorLevelError, strings.TrimSpace(error)))
+	if errorStr != "" {
+		_, _ = fmt.Fprintln(out, c.C(ColorLevelError, strings.TrimSpace(errorStr)))
 	}
 
 	if st != "" {


### PR DESCRIPTION
This pull request includes changes to enhance the handling of null values in the extra fields section and improve code clarity. The most important changes include adding a new command-line option to show null values and modifying the code to hide null values by default.

Enhancements to null value handling:

* [`Changes.md`](diffhunk://#diff-46efb9fafbbb11cf26bd8ac10f0bc5df02ac0e42f593b87cce382e712b8cf950R1-R5): Added a new `--show-null` option to show null values in the extra fields section and updated the documentation to reflect this change.
* [`cmd.go`](diffhunk://#diff-2d4f0818f10044b5b4b2e35d988be49d71de6e2f9b7b23f996ed3daac8194cb9R35): Introduced a new `showNull` boolean variable and added a corresponding command-line flag to control the display of null values. [[1]](diffhunk://#diff-2d4f0818f10044b5b4b2e35d988be49d71de6e2f9b7b23f996ed3daac8194cb9R35) [[2]](diffhunk://#diff-2d4f0818f10044b5b4b2e35d988be49d71de6e2f9b7b23f996ed3daac8194cb9R51)
* [`output.go`](diffhunk://#diff-35d16970a063a59d666ecdce46f6ac3363f36d17a3e672d8ff69f9ef2056d4cbR71-R80): Modified the `outputFormattedLogLine` function to hide null values by default and added logic to filter out null values from `lineData` when `showNull` is false.

Code clarity improvements:

* [`output.go`](diffhunk://#diff-35d16970a063a59d666ecdce46f6ac3363f36d17a3e672d8ff69f9ef2056d4cbL51-R51): Renamed the `error` variable to `errorStr` to avoid shadowing built-in error handling and improve code readability. [[1]](diffhunk://#diff-35d16970a063a59d666ecdce46f6ac3363f36d17a3e672d8ff69f9ef2056d4cbL51-R51) [[2]](diffhunk://#diff-35d16970a063a59d666ecdce46f6ac3363f36d17a3e672d8ff69f9ef2056d4cbL83-R94)