### PR TITLE
cicd: add github actions to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,10 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
 updates:
-  - package-ecosystem: "gomod" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem:
+    directory: /
     schedule:
-      interval: "weekly"
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  - package-ecosystem:
+  - package-ecosystem: gomod
     directory: /
     schedule:
       interval: weekly


### PR DESCRIPTION
This pull request updates the `.github/dependabot.yml` configuration to include GitHub Actions dependencies and simplifies the structure of the file.

### Updates to Dependabot configuration:

* Added support for updating GitHub Actions dependencies with a weekly schedule. (`[.github/dependabot.ymlL1-R10](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L1-R10)`)
* Simplified formatting by removing unnecessary quotes around values and comments. (`[.github/dependabot.ymlL1-R10](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L1-R10)`)