### PR TITLE
chore(deps): dependabot sweep 2026-05-11

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,7 @@
+## Unreleased  2026-05-11
+
+ * Merged Dependabot PR #39: bump golang.org/x/sys from 0.43.0 to 0.44.0.
+
 ## 0.2.1  2026-03-09
 
  * Upgraded Go from v1.24 to v1.25.


### PR DESCRIPTION
## Summary

Dependabot maintenance sweep for 2026-05-11.

### PRs merged

- #39 — chore(deps): bump golang.org/x/sys from 0.43.0 to 0.44.0

### Vulnerabilities

No open Dependabot alerts.

### Changelog

Added an Unreleased section to `Changes.md` recording the merged update.