### PR TITLE
chore(deps): dependabot sweep 2026-07-20

### DIFF
--- a/.github/workflows/prepare.yaml
+++ b/.github/workflows/prepare.yaml
@@ -10,7 +10,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
         - uses: actions/checkout@v7
-        - uses: actions/setup-go@v6
+        - uses: actions/setup-go@v7
           with:
             go-version: 1.25
         - name: Release Version

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ jobs:
       GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@v7
         with:
           go-version: 1.25
       - name: Release Version

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@v7
         with:
           go-version: 1.25
           cache: false

--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,7 @@
+## Unreleased  2026-07-20
+
+ * Merged Dependabot PR #51: chore(deps): bump actions/setup-go from 6 to 7
+
 ## Unreleased  2026-07-14
 
  * Merged Dependabot PR #49: chore(deps): bump golang.org/x/sys from 0.46.0 to 0.47.0


### PR DESCRIPTION
Weekly Dependabot maintenance sweep.

## PRs batch-merged
- Closes #51 — chore(deps): bump actions/setup-go from 6 to 7

## Vulnerabilities fixed
None (no open Dependabot alerts).

## Changelog
Updated Changes.md with an entry for this sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)