### PR TITLE
docs: correct stale golangci-lint version in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,10 +45,10 @@ go test -v ./...       # Verbose test output
 
 ### Linting
 ```bash
-golangci-lint run      # Run linter (requires golangci-lint v2.3.0+)
+golangci-lint run      # Run linter (requires golangci-lint v2.4.0+)
 ```
 
-The project uses golangci-lint in CI with specific version v2.3.0. Local development should use compatible versions.
+The project uses golangci-lint in CI with specific version v2.4.0. Local development should use compatible versions.
 
 ### Coverage
 ```bash


### PR DESCRIPTION
`CLAUDE.md` documented golangci-lint `v2.3.0` in two places, but CI pins `v2.4.0` in `.github/workflows/test.yaml`, and `Changes.md` (0.2.1) records "Upgraded golangci-lint to v2.4.0 to support Go 1.25." Contributors — and Claude Code, which treats CLAUDE.md as authoritative — could install v2.3.0 locally and get lint results that disagree with CI.

Both references now read `v2.4.0`. Verified that no `2.3.0` references remain anywhere in the repo.

No `Changes.md` entry: this is internal contributor documentation with no user-facing effect, unlike the CI and dependency changes that file tracks.

Fixes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)