### PR TITLE
fix: correct inverted tty detection for --color=auto

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -2,6 +2,8 @@
 
  * Fixed tty detection, which was inverted: `--color=auto` (the default) treated a terminal as a non-terminal and vice versa. As a workaround, `auto` had been forced to `on`, so ANSI escapes were written even when output was piped or redirected to a file.
  * `--color=auto` now detects the actual output destination, so `-o file` is no longer colorized when standard output happens to be a terminal. Use `--color=on` to force color when piping into a pager such as `less -R`.
+ * Fixed `-o`/`--output`, which opened the output file read-only. Every write failed and the error was discarded, so the file was left empty and logfmt still exited 0. Appending with `-a` did not create the file if it was missing.
+ * Fixed the error message for an unopenable output file, which formatted the nil file handle instead of the file name.
  * `--color=auto` now honors the custom palette from `.logfmt.yaml` instead of always using the default palette.
 
 ## Unreleased  2026-08-12

--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,9 @@
+## Unreleased  2026-08-13
+
+ * Fixed tty detection, which was inverted: `--color=auto` (the default) treated a terminal as a non-terminal and vice versa. As a workaround, `auto` had been forced to `on`, so ANSI escapes were written even when output was piped or redirected to a file.
+ * `--color=auto` now detects the actual output destination, so `-o file` is no longer colorized when standard output happens to be a terminal. Use `--color=on` to force color when piping into a pager such as `less -R`.
+ * `--color=auto` now honors the custom palette from `.logfmt.yaml` instead of always using the default palette.
+
 ## Unreleased  2026-08-12
 
  * Fixed the CI coverage step, which filtered the package list on the wrong module path (`github.com/zostay/today`).

--- a/Changes.md
+++ b/Changes.md
@@ -4,6 +4,8 @@
  * `--color=auto` now detects the actual output destination, so `-o file` is no longer colorized when standard output happens to be a terminal. Use `--color=on` to force color when piping into a pager such as `less -R`.
  * Fixed `-o`/`--output`, which opened the output file read-only. Every write failed and the error was discarded, so the file was left empty and logfmt still exited 0. Appending with `-a` did not create the file if it was missing.
  * Fixed the error message for an unopenable output file, which formatted the nil file handle instead of the file name.
+ * An unrecognized `--color` value (or `colorize` setting) is now an error listing the valid modes, instead of being silently treated as `auto`. The check runs before the output file is opened, so a typo no longer truncates an existing `-o` file.
+ * Error messages written to standard error now end with a newline.
  * `--color=auto` now honors the custom palette from `.logfmt.yaml` instead of always using the default palette.
 
 ## Unreleased  2026-08-12

--- a/cmd.go
+++ b/cmd.go
@@ -106,15 +106,15 @@ func setupOutput() (io.Writer, error) {
 	var output io.Writer = os.Stdout
 	if outputFile != "" && outputFile != "-" {
 		var err error
-		flags := os.O_CREATE
+		flags := os.O_CREATE | os.O_WRONLY | os.O_TRUNC
 		mode := "create"
 		if appendToFile {
-			flags = os.O_APPEND
+			flags = os.O_CREATE | os.O_WRONLY | os.O_APPEND
 			mode = "append to"
 		}
 		output, err = os.OpenFile(outputFile, flags, 0644)
 		if err != nil {
-			return nil, fmt.Errorf("failed to %s %q: %v", mode, output, err)
+			return nil, fmt.Errorf("failed to %s %q: %v", mode, outputFile, err)
 		}
 	}
 

--- a/cmd.go
+++ b/cmd.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -124,15 +125,32 @@ func setupOutput() (io.Writer, error) {
 // onErrReportAndQuit handles an error by writing it to standard error and exiting.
 func onErrReportAndQuit(err error) {
 	if err != nil {
-		_, _ = fmt.Fprint(os.Stderr, err)
+		_, _ = fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
+}
+
+// colorModes are the accepted --color values. An empty value means the mode
+// was never set, which behaves as auto.
+var colorModes = []string{"auto", "on", "off"}
+
+// checkColorizeMode rejects an unrecognized --color value. It is checked before
+// the output file is opened, so a typo does not truncate an existing file.
+func checkColorizeMode() error {
+	switch colorize {
+	case "off", "on", "auto", "":
+		return nil
+	}
+	return fmt.Errorf("invalid --color mode %q: expected one of %s", colorize, strings.Join(colorModes, ", "))
 }
 
 // setupColorizer builds the colorizer for output. In "auto" mode, color is
 // enabled only when output is a terminal, which requires output to be the
 // *os.File returned by setupOutput. Wrapping it (in a bufio.Writer, say) would
 // hide the descriptor and silently disable color in the default mode.
+//
+// The mode is expected to have passed checkColorizeMode already, so an
+// unrecognized value falls through to auto rather than being rejected here.
 func setupColorizer(output io.Writer) *SugaredColorizer {
 	// Get custom palette from config
 	palette := DefaultPalette
@@ -188,6 +206,10 @@ func formatLogLines(cmd *cobra.Command, args []string) {
 	}
 
 	setupWorries(config)
+
+	// Check this before opening the output file, so an invalid mode does not
+	// truncate an existing file on the way to the error.
+	onErrReportAndQuit(checkColorizeMode())
 
 	input, err := setupInput(args)
 	onErrReportAndQuit(err)

--- a/cmd.go
+++ b/cmd.go
@@ -130,7 +130,9 @@ func onErrReportAndQuit(err error) {
 }
 
 // setupColorizer builds the colorizer for output. In "auto" mode, color is
-// enabled only when output is a terminal.
+// enabled only when output is a terminal, which requires output to be the
+// *os.File returned by setupOutput. Wrapping it (in a bufio.Writer, say) would
+// hide the descriptor and silently disable color in the default mode.
 func setupColorizer(output io.Writer) *SugaredColorizer {
 	// Get custom palette from config
 	palette := DefaultPalette

--- a/cmd.go
+++ b/cmd.go
@@ -129,12 +129,9 @@ func onErrReportAndQuit(err error) {
 	}
 }
 
-func setupColorizer() *SugaredColorizer {
-	// FIXME tty detection is broken, so...
-	if colorize == "auto" {
-		colorize = "on"
-	}
-
+// setupColorizer builds the colorizer for output. In "auto" mode, color is
+// enabled only when output is a terminal.
+func setupColorizer(output io.Writer) *SugaredColorizer {
 	// Get custom palette from config
 	palette := DefaultPalette
 	if config != nil {
@@ -152,7 +149,7 @@ func setupColorizer() *SugaredColorizer {
 	case "on":
 		colorizer = NewSugaredColorizer(NewColorOn(palette))
 	default:
-		colorizer = NewSugaredColorizer(NewColorAuto())
+		colorizer = NewSugaredColorizer(NewColorAuto(palette, output))
 	}
 	return colorizer
 }
@@ -196,7 +193,7 @@ func formatLogLines(cmd *cobra.Command, args []string) {
 	output, err := setupOutput()
 	onErrReportAndQuit(err)
 
-	colorizer := setupColorizer()
+	colorizer := setupColorizer(output)
 
 	buffed := bufio.NewScanner(input)
 	for buffed.Scan() {

--- a/cmd_test.go
+++ b/cmd_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSetupColorizerMode pins down which colorizer each --color value selects.
+// Without this, restoring the old "auto is broken, force it on" workaround
+// leaves the suite green.
+func TestSetupColorizerMode(t *testing.T) {
+	orig := colorize
+	t.Cleanup(func() { colorize = orig })
+
+	tests := map[string]any{
+		"off":  &ColorOff{},
+		"on":   &ColorOn{},
+		"auto": &ColorAuto{},
+		"":     &ColorAuto{},
+	}
+
+	for mode, want := range tests {
+		colorize = mode
+
+		// A buffer is never a terminal, so auto resolves to a ColorAuto with
+		// color disabled rather than being rewritten to "on".
+		colorizer := setupColorizer(&bytes.Buffer{})
+
+		require.NotNil(t, colorizer, "colorizer built for %q", mode)
+		assert.IsType(t, want, colorizer.PlainColorizer, "colorizer type for --color=%q", mode)
+	}
+}
+
+// TestSetupColorizerAutoIsOffForNonTerminal is the end-to-end guard for the
+// regression in issue #1: in the default mode, output that is not a terminal
+// must carry no escape sequences.
+func TestSetupColorizerAutoIsOffForNonTerminal(t *testing.T) {
+	orig := colorize
+	t.Cleanup(func() { colorize = orig })
+
+	colorize = "auto"
+
+	colorizer := setupColorizer(&bytes.Buffer{})
+
+	assert.Equal(t, "boom", colorizer.C(ColorLevelError, "boom"), "no color when output is not a terminal")
+}

--- a/cmd_test.go
+++ b/cmd_test.go
@@ -37,6 +37,29 @@ func TestSetupColorizerMode(t *testing.T) {
 	}
 }
 
+// TestCheckColorizeMode covers the accepted --color values and the rejection of
+// anything else, which previously fell through to auto and silently turned
+// color off on a typo.
+func TestCheckColorizeMode(t *testing.T) {
+	orig := colorize
+	t.Cleanup(func() { colorize = orig })
+
+	for _, mode := range []string{"auto", "on", "off", ""} {
+		colorize = mode
+		assert.NoError(t, checkColorizeMode(), "%q is a valid mode", mode)
+	}
+
+	for _, mode := range []string{"bogus", "ON", "yes", "true", "aut"} {
+		colorize = mode
+
+		err := checkColorizeMode()
+
+		require.Error(t, err, "%q is rejected", mode)
+		assert.Contains(t, err.Error(), mode, "error names the bad mode")
+		assert.Contains(t, err.Error(), "auto, on, off", "error lists the valid modes")
+	}
+}
+
 // TestSetupOutputWritesToFile guards against the output file being opened
 // read-only: writes then fail with EBADF, and because the callers in output.go
 // discard write errors, -o produced an empty file and exited 0.

--- a/cmd_test.go
+++ b/cmd_test.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -32,6 +35,65 @@ func TestSetupColorizerMode(t *testing.T) {
 		require.NotNil(t, colorizer, "colorizer built for %q", mode)
 		assert.IsType(t, want, colorizer.PlainColorizer, "colorizer type for --color=%q", mode)
 	}
+}
+
+// TestSetupOutputWritesToFile guards against the output file being opened
+// read-only: writes then fail with EBADF, and because the callers in output.go
+// discard write errors, -o produced an empty file and exited 0.
+func TestSetupOutputWritesToFile(t *testing.T) {
+	origFile, origAppend := outputFile, appendToFile
+	t.Cleanup(func() { outputFile, appendToFile = origFile, origAppend })
+
+	path := filepath.Join(t.TempDir(), "out.log")
+	outputFile, appendToFile = path, false
+
+	output, err := setupOutput()
+	require.NoError(t, err, "setup output")
+
+	_, err = fmt.Fprintln(output, "written")
+	require.NoError(t, err, "write to output file")
+	require.NoError(t, output.(*os.File).Close(), "close output file")
+
+	content, err := os.ReadFile(path)
+	require.NoError(t, err, "read back output file")
+	assert.Equal(t, "written\n", string(content), "output reaches the file")
+}
+
+// TestSetupOutputAppends checks that --append keeps existing content, which the
+// missing O_CREATE in the append branch also affected.
+func TestSetupOutputAppends(t *testing.T) {
+	origFile, origAppend := outputFile, appendToFile
+	t.Cleanup(func() { outputFile, appendToFile = origFile, origAppend })
+
+	path := filepath.Join(t.TempDir(), "out.log")
+	require.NoError(t, os.WriteFile(path, []byte("first\n"), 0644), "seed output file")
+
+	outputFile, appendToFile = path, true
+
+	output, err := setupOutput()
+	require.NoError(t, err, "setup output")
+
+	_, err = fmt.Fprintln(output, "second")
+	require.NoError(t, err, "write to output file")
+	require.NoError(t, output.(*os.File).Close(), "close output file")
+
+	content, err := os.ReadFile(path)
+	require.NoError(t, err, "read back output file")
+	assert.Equal(t, "first\nsecond\n", string(content), "append preserves existing content")
+}
+
+// TestSetupOutputMissingDirectory checks the error names the file rather than
+// the nil writer.
+func TestSetupOutputMissingDirectory(t *testing.T) {
+	origFile, origAppend := outputFile, appendToFile
+	t.Cleanup(func() { outputFile, appendToFile = origFile, origAppend })
+
+	outputFile, appendToFile = filepath.Join(t.TempDir(), "no-such-dir", "out.log"), false
+
+	_, err := setupOutput()
+
+	require.Error(t, err, "opening a file in a missing directory fails")
+	assert.Contains(t, err.Error(), outputFile, "error names the output file")
 }
 
 // TestSetupColorizerAutoIsOffForNonTerminal is the end-to-end guard for the

--- a/color.go
+++ b/color.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	gc "image/color"
+	"io"
 	"os"
 	"strings"
 
@@ -81,22 +82,33 @@ func (rc *RawColorizer) C(c gc.Color, v ...any) string {
 	return color.RGBA(gc.RGBA{R: uint8(r >> 8), G: uint8(g >> 8), B: uint8(b >> 8), A: uint8(a >> 8)}).Sprint(v...)
 }
 
+// isTerminal reports whether w writes to a terminal. Anything that is not an
+// open file (a buffer, a network connection) is never a terminal. For files,
+// the window-size ioctl succeeds only on a terminal device, which distinguishes
+// a terminal from a pipe, a regular file, and character devices like /dev/null.
+func isTerminal(w io.Writer) bool {
+	f, ok := w.(*os.File)
+	if !ok {
+		return false
+	}
+
+	_, err := unix.IoctlGetWinsize(int(f.Fd()), unix.TIOCGWINSZ)
+	return err == nil
+}
+
 type ColorAuto struct {
 	on  *ColorOn
 	off *ColorOff
 	tty bool
 }
 
-func NewColorAuto() *ColorAuto {
-	ca := ColorAuto{
-		on:  NewColorOn(DefaultPalette),
+// NewColorAuto builds a colorizer that emits color only when out is a terminal.
+func NewColorAuto(p Palette, out io.Writer) *ColorAuto {
+	return &ColorAuto{
+		on:  NewColorOn(p),
 		off: &ColorOff{},
+		tty: isTerminal(out),
 	}
-
-	_, err := unix.IoctlGetWinsize(int(os.Stdout.Fd()), unix.TIOCGWINSZ)
-	ca.tty = err != nil
-
-	return &ca
 }
 
 func (ca *ColorAuto) C(c ColorName, v ...any) string {

--- a/color_test.go
+++ b/color_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIsTerminalNotATerminal covers the destinations logfmt output actually
+// gets redirected to. Each of these must report false, or logfmt writes ANSI
+// escapes into a pipe or a file.
+func TestIsTerminalNotATerminal(t *testing.T) {
+	pr, pw, err := os.Pipe()
+	require.NoError(t, err, "open pipe")
+	defer func() { _ = pr.Close() }()
+	defer func() { _ = pw.Close() }()
+
+	regular, err := os.Create(filepath.Join(t.TempDir(), "out.log"))
+	require.NoError(t, err, "create regular file")
+	defer func() { _ = regular.Close() }()
+
+	// /dev/null is a character device, so a mode-based check misidentifies it
+	// as a terminal.
+	devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	require.NoError(t, err, "open %s", os.DevNull)
+	defer func() { _ = devNull.Close() }()
+
+	notTerminals := map[string]io.Writer{
+		"pipe":         pw,
+		"regular file": regular,
+		os.DevNull:     devNull,
+		"buffer":       &bytes.Buffer{},
+	}
+
+	for name, w := range notTerminals {
+		assert.False(t, isTerminal(w), "%s is not a terminal", name)
+	}
+}
+
+// TestIsTerminalTerminal checks the positive case against the controlling
+// terminal. There is no controlling terminal under CI or `go test` without a
+// tty, so the test skips rather than fails there.
+func TestIsTerminalTerminal(t *testing.T) {
+	tty, err := os.OpenFile("/dev/tty", os.O_WRONLY, 0)
+	if err != nil {
+		t.Skipf("no controlling terminal available: %v", err)
+	}
+	defer func() { _ = tty.Close() }()
+
+	assert.True(t, isTerminal(tty), "/dev/tty is a terminal")
+}
+
+// TestColorAutoOffWhenNotATerminal is the regression guard for issue #1: with
+// the detection inverted, auto mode colorized piped and redirected output.
+func TestColorAutoOffWhenNotATerminal(t *testing.T) {
+	regular, err := os.Create(filepath.Join(t.TempDir(), "out.log"))
+	require.NoError(t, err, "create regular file")
+	defer func() { _ = regular.Close() }()
+
+	ca := NewColorAuto(DefaultPalette, regular)
+	require.False(t, ca.tty, "auto mode detects non-terminal")
+
+	got := ca.C(ColorLevelError, "boom")
+	assert.Equal(t, "boom", got, "no escape sequences when output is not a terminal")
+}
+
+// TestColorAutoUsesSuppliedPalette guards against auto mode falling back to the
+// default palette and ignoring configured colors.
+func TestColorAutoUsesSuppliedPalette(t *testing.T) {
+	custom := Palette{ColorLevelError: RGB(0x01, 0x02, 0x03)}
+
+	ca := NewColorAuto(custom, &bytes.Buffer{})
+
+	assert.Equal(t, custom, ca.on.palette, "auto mode keeps the supplied palette")
+}

--- a/color_test.go
+++ b/color_test.go
@@ -43,12 +43,14 @@ func TestIsTerminalNotATerminal(t *testing.T) {
 }
 
 // TestIsTerminalTerminal checks the positive case against the controlling
-// terminal. There is no controlling terminal under CI or `go test` without a
-// tty, so the test skips rather than fails there.
+// terminal. There is no controlling terminal under CI, so this skips there and
+// isTerminal's true path is left unverified: allocating a pty in-process would
+// need a test-only dependency such as github.com/creack/pty. The tests below
+// still cover ColorAuto's color-enabled branch by setting tty directly.
 func TestIsTerminalTerminal(t *testing.T) {
 	tty, err := os.OpenFile("/dev/tty", os.O_WRONLY, 0)
 	if err != nil {
-		t.Skipf("no controlling terminal available: %v", err)
+		t.Skipf("no controlling terminal available, isTerminal's true path is unverified here: %v", err)
 	}
 	defer func() { _ = tty.Close() }()
 
@@ -69,12 +71,38 @@ func TestColorAutoOffWhenNotATerminal(t *testing.T) {
 	assert.Equal(t, "boom", got, "no escape sequences when output is not a terminal")
 }
 
+// TestColorAutoOnWhenTerminal covers the branch that no environment-dependent
+// test can reach: /dev/tty is unavailable under CI, so without this the "color
+// is on" half of auto mode is never executed and detection that always returns
+// false would pass the suite.
+func TestColorAutoOnWhenTerminal(t *testing.T) {
+	ca := &ColorAuto{on: NewColorOn(DefaultPalette), off: &ColorOff{}, tty: true}
+
+	got := ca.C(ColorLevelError, "boom")
+
+	assert.Contains(t, got, "\x1b[38;2;255;215;0m", "error color escape emitted on a terminal")
+	assert.Contains(t, got, "boom", "text preserved")
+}
+
 // TestColorAutoUsesSuppliedPalette guards against auto mode falling back to the
-// default palette and ignoring configured colors.
+// default palette and ignoring configured colors. It asserts on the emitted
+// escape rather than the stored palette, so it fails if the palette is kept but
+// never consulted.
 func TestColorAutoUsesSuppliedPalette(t *testing.T) {
+	custom := Palette{ColorLevelError: RGB(0x01, 0x02, 0x03)}
+
+	ca := &ColorAuto{on: NewColorOn(custom), off: &ColorOff{}, tty: true}
+
+	assert.Contains(t, ca.C(ColorLevelError, "boom"), "38;2;1;2;3", "custom color used, not the default palette")
+}
+
+// TestNewColorAutoWiring checks that NewColorAuto passes the palette and the
+// detection result through, since the tests above build ColorAuto directly.
+func TestNewColorAutoWiring(t *testing.T) {
 	custom := Palette{ColorLevelError: RGB(0x01, 0x02, 0x03)}
 
 	ca := NewColorAuto(custom, &bytes.Buffer{})
 
-	assert.Equal(t, custom, ca.on.palette, "auto mode keeps the supplied palette")
+	assert.Equal(t, custom, ca.on.palette, "supplied palette reaches the on colorizer")
+	assert.False(t, ca.tty, "buffer is not a terminal")
 }

--- a/config.go
+++ b/config.go
@@ -225,7 +225,7 @@ CONFIGURATION OPTIONS:
 Output Options:
   output_file: "-"              # Output file ("-" for stdout)  
   append_to_file: false         # Append to output file
-  colorize: "auto"              # Color mode: "auto", "on", "off"
+  colorize: "auto"              # Color mode: "auto" (color only on a terminal), "on", "off"
 
 Processing Options:
   highlight_worry_words: true   # Highlight error/warning keywords


### PR DESCRIPTION
Fixes #1.

## Still a problem?

Yes. `NewColorAuto` ran the window-size ioctl on stdout and stored `err != nil`, but that ioctl **succeeds** on a terminal and **fails** otherwise — so the result was exactly backwards. Verified against a real pty:

| stdout | ioctl err | old code set `tty` | correct |
|---|---|---|---|
| real tty | `<nil>` | **false** | true |
| pipe | `inappropriate ioctl for device` | **true** | false |

Because of this, `setupColorizer` carried a `// FIXME tty detection is broken` workaround that forced `auto` → `on`. Since `auto` is the default, logfmt wrote ANSI escapes into pipes and files for every user who had not set `--color` explicitly.

## Changes

**The tty fix**

- **`color.go`** — fixed the inversion (`err == nil`) and extracted `isTerminal(io.Writer)`. Non-files (buffers, connections) are never terminals. Kept the ioctl rather than an `os.ModeCharDevice` check, since `/dev/null` is a character device and would be misreported as a terminal.
- **`cmd.go`** — removed the FIXME workaround. Detection runs against the **actual output stream**, not always `os.Stdout`, so `-o file` is not colorized just because stdout is a terminal. `auto` now also receives the configured palette; it previously hardcoded `DefaultPalette`, so re-enabling it would have ignored custom colors from `.logfmt.yaml`.

**Found by review, on the same code path**

- **`-o`/`--output` wrote nothing at all.** `setupOutput` passed `os.O_CREATE` alone, which is `O_RDONLY|O_CREAT`, so every write failed with `EBADF`. The callers in `output.go` discard write errors, so logfmt left an **empty file** and exited 0. The append branch passed `os.O_APPEND` alone, which additionally would not create a missing file. This also made the original "auto does not colorize `-o file`" claim vacuous — the file was empty either way.
- The open-failure message formatted the nil file handle instead of the file name (`%!q(*os.File=<nil>)`).
- **An unrecognized `--color` value is now an error** listing the valid modes. It previously fell through to `auto`; harmless while `auto` was forced to `on`, but after this fix a typo silently *disables* color. The check runs before the output file is opened, so a bad mode does not truncate an existing `-o` file. Error output gained a trailing newline.

## Verification

End-to-end against a built binary, using a real pty via `script`:

| invocation | result |
|---|---|
| `auto` → tty | colorized |
| `auto` → pipe | plain |
| `auto` → `-o file` | plain, **56 bytes written** (was 0) |
| `--color=on` → pipe | colorized (override still works) |
| `-a -o file` | appends |
| `--color=bogus` | errors, exit 1, existing `-o` file left intact |

Tests were mutation-checked: the tty tests fail against the original inverted logic, and the `setupOutput` tests fail against the original flags. Coverage 21.6% → 34.6%. `gofmt`, `golangci-lint run` (0 issues), and `go test ./...` all clean.

## Known gap

`isTerminal`'s **true** path is not covered in CI — `/dev/tty` is unavailable there, and an in-process pty would need a test-only dependency such as `creack/pty`. `ColorAuto`'s color-enabled branch *is* covered by constructing the struct directly. The gap is noted in the skip message and test comments rather than left to look covered.

## Behavior changes worth noting

- Piping now suppresses color where the forced-`on` workaround emitted it — `logfmt | less -R` needs `--color=on`. This is the documented intent of `auto`.
- An invalid `--color` value is now fatal rather than ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)